### PR TITLE
fix(matrix): Fix wrong determinant sign — permutation parity via cycle decomposition

### DIFF
--- a/matrix.py
+++ b/matrix.py
@@ -375,12 +375,22 @@ class Matrix:
             for i in range(U.rows):
                 det_U *= U.data[i][i]
 
-            # Count permutations to get sign
-            perm_count = sum(1 for i in range(len(P)) if P[i] != i)
-            det_P = (-1) ** perm_count
+            # Count permutation sign using cycle decomposition
+            visited = [False] * len(P)
+            transpositions = 0
+            for i in range(len(P)):
+                if not visited[i]:
+                    cycle_len = 0
+                    j = i
+                    while not visited[j]:
+                        visited[j] = True
+                        j = P[j]
+                        cycle_len += 1
+                    transpositions += cycle_len - 1
+            det_P = (-1) ** transpositions
 
             return det_P * det_U
-        except:
+        except Exception:
             # Fallback to cofactor expansion
             return self._determinant_cofactor()
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -76,8 +76,7 @@ class TestMatrixProperties(unittest.TestCase):
         """Test 3x3 determinant."""
         m = Matrix([[1, 2, 3], [0, 1, 4], [5, 6, 0]])
         det = m.determinant()
-        # Check absolute value (sign may vary with permutation implementation)
-        self.assertAlmostEqual(abs(det), 1.0)
+        self.assertAlmostEqual(det, 1.0)
 
     def test_rank(self):
         """Test rank computation."""


### PR DESCRIPTION
## Bug
Closes #11

## Root Cause
`determinant()` computed permutation parity by counting non-fixed positions in P (`P[i] != i`). This is wrong: it counts non-fixed *positions*, not *transpositions*.

**Counter-example:** `P = [2, 1, 0]`
- Non-fixed positions: indices 0 and 2 → `perm_count = 2` → `det_P = +1` ❌
- Cycle structure: `(0 → 2 → 0)` + `(1 → 1)` = **1 transposition** → `det_P = -1` ✓

This made `det([[1,2,3],[0,1,4],[5,6,0]])` return `-1.0` instead of the correct `+1.0`.

## Changes
| File | Change |
|---|---|
| `matrix.py` | Replace non-fixed-point count with cycle-decomposition algorithm |
| `matrix.py` | `except:` → `except Exception:` (separate from parity, fixes #13 partially) |
| `tests/test_matrix.py` | Remove `abs()` wrapper that was masking the wrong sign |

## Verification
```python
m = Matrix([[1, 2, 3], [0, 1, 4], [5, 6, 0]])
assert m.determinant() == pytest.approx(1.0)   # ✓ was -1.0 before

m2 = Matrix([[0, 1], [1, 0]])
assert m2.determinant() == pytest.approx(-1.0)  # ✓ still correct
```