### PR TITLE
fix(tensor): Fix Tensor.softmax() broken with default axis=-1 on 2D tensors

### DIFF
--- a/tensor.py
+++ b/tensor.py
@@ -383,6 +383,10 @@ class Tensor:
         Returns:
             Softmax probabilities
         """
+        # Normalize negative axis (e.g. axis=-1 means last axis)
+        if self.ndim > 0 and axis < 0:
+            axis = self.ndim + axis
+
         if self.ndim == 1:
             # 1D softmax
             max_val = max(self.data)


### PR DESCRIPTION
## Bug
Closes #12

## Root Cause
`softmax()` defaults to `axis=-1` (semantically "last axis"), but the 2D branch checked `axis == 1` literally — negative indices were never normalized.

```python
# Before fix
def softmax(self, axis: int = -1) -> 'Tensor':
    if self.ndim == 1:
        ...  # OK — doesn't check axis
    elif self.ndim == 2 and axis == 1:  # axis is -1, never True
        ...
    raise NotImplementedError(...)     # always reached for 2D!
```

## Reproduction
```python
t = Tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
t.softmax()         # NotImplementedError ❌
t.softmax(axis=1)   # works ✓
```

## Fix
Add axis normalization at the start of `softmax()`:
```python
if self.ndim > 0 and axis < 0:
    axis = self.ndim + axis
```

## After Fix
```python
t.softmax()          # works ✓  (axis -1 → 1)
t.softmax(axis=-1)   # works ✓
t.softmax(axis=1)    # works ✓
```

## Impact
The default call `tensor.softmax()` on any 2D output layer (classification heads) was broken. This is the most common use case.