### PR TITLE
fix(matrix): Fix spectral_norm() silently returning Frobenius norm for matrices > 3×3

### DIFF
--- a/matrix.py
+++ b/matrix.py
@@ -618,13 +618,9 @@ class Matrix:
         Returns:
             Spectral norm (largest singular value)
         """
-        # For small matrices, compute directly via power iteration
-        # This is a placeholder - full implementation in decomposition module
-        if self.rows <= 3 and self.cols <= 3:
-            # Use power iteration for largest eigenvalue of A^T A
-            AtA = self.T.multiply(self)
-            return math.sqrt(self._power_iteration(AtA))
-        return self.frobenius_norm()  # Approximation for now
+        # Use power iteration for largest eigenvalue of A^T A
+        AtA = self.T.multiply(self)
+        return math.sqrt(self._power_iteration(AtA))
 
     def _power_iteration(self, matrix: 'Matrix', num_iterations: int = 100) -> float:
         """Power iteration to find largest eigenvalue."""


### PR DESCRIPTION
## Bug
Closes #13

## Root Cause
`spectral_norm()` had a size guard that silently returned `frobenius_norm()` for any matrix larger than 3×3:

```python
# Before
if self.rows <= 3 and self.cols <= 3:
    AtA = self.T.multiply(self)
    return math.sqrt(self._power_iteration(AtA))
return self.frobenius_norm()  # Silently wrong for 4x4+!
```

The Frobenius norm is always **≥** the spectral norm: `‖A‖_F ≤ √rank · ‖A‖_2`. For a 4×4 matrix this overestimate can be up to 4×. No warning was emitted.

## Fix
Power iteration works for any matrix size — remove the guard entirely:
```python
# After
AtA = self.T.multiply(self)
return math.sqrt(self._power_iteration(AtA))
```

## Impact
Any code using `spectral_norm()` for spectral normalization (GANs, Lipschitz regularization) on matrices larger than 3×3 received silently wrong values.