### PR TITLE
chore(package): Set up public API and correct version to 0.1.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,35 @@
+"""
+Linear Algebra Library for AI/ML/DL
+====================================
+
+A comprehensive linear algebra library built from scratch in Python,
+designed specifically for understanding the mathematical foundations
+of AI, Machine Learning, and Deep Learning.
+
+Modules:
+--------
+- vector: Vector operations and computations
+- matrix: Matrix operations and computations
+- decomposition: Matrix decompositions (LU, QR, Cholesky, SVD)
+- eigenvalues: Eigenvalue and eigenvector computations
+- transformations: Linear transformations
+- projections: Projections and orthogonalization
+- tensor: Tensor operations for deep learning
+"""
+
+from .vector import Vector
+from .matrix import Matrix
+from .tensor import Tensor
+from . import decomposition
+from . import transformations
+from . import projections
+
+__version__ = "0.1.0"
+__all__ = [
+    "Vector",
+    "Matrix",
+    "Tensor",
+    "decomposition",
+    "transformations",
+    "projections"
+]


### PR DESCRIPTION
## Summary
Closes #14

- Adds `__init__.py` with the public API surface:
  ```python
  from LinearAlgebra import Vector, Matrix, Tensor
  from LinearAlgebra import decomposition, transformations, projections
  ```
- Corrects version from `"1.0.0"` → `"0.1.0"`
  - `1.0.0` implies stable, complete, production-ready — which is false
  - Several `NotImplementedError` paths remain (high-dim tensor ops)
  - Test coverage is ~30% (no tests for Tensor, transformations, projections)
  - Semantic versioning: MAJOR=0 signals pre-stable

## Files Changed
- `__init__.py` — new file

## Test plan
- [ ] `python -c "import LinearAlgebra; print(LinearAlgebra.__version__)"` prints `0.1.0`
- [ ] `from LinearAlgebra import Vector, Matrix, Tensor` works
- [ ] `from LinearAlgebra import decomposition; decomposition.svd(...)` works